### PR TITLE
ci(.github/workflows/go): tests against `go@1.22`.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,7 @@ jobs:
           - '1.19'
           - '1.20'
           - '1.21'
+          - '1.22'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
TSIA!