### PR TITLE
feat(deps): upgrades to go@1.24.0.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,8 +34,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '1.23'
           - '1.24'
+          - '1.25'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewhartstonge/argon2
 
-go 1.23.0
+go 1.24.0
 
 require golang.org/x/crypto v0.41.0
 


### PR DESCRIPTION
preparation for next x/crypto bump which requires `go@1.24`