### PR TITLE
restore support for 32-bit platforms

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -270,7 +270,7 @@ func Decode(encoded []byte) (Raw, error) {
 	hash := make([]byte, enc64.DecodedLen(len(h)))
 	sl, se := enc64.Decode(salt, s)
 	hl, he := enc64.Decode(hash, h)
-	if se != nil || he != nil || sl <= 0 || hl <= 0 || sl > math.MaxUint32 || hl > math.MaxUint32 {
+	if se != nil || he != nil || sl <= 0 || hl <= 0 || uint64(sl) > math.MaxUint32 || uint64(hl) > math.MaxUint32 {
 		return Raw{}, ErrDecodingFail
 	}
 


### PR DESCRIPTION
PR #127 addressed a gosec-triggered warning and introduced additional checks on salt length and hash length, preventing them from being greater than MaxUint32. These checks prevent the library from being compiled on 32-bit platforms, since, on these platforms, salt length and hash length are 32-bit integers and cannot be compared to MaxUint32 due to an overflow. This patch fixes the issue by casting ints as uint64s.

You can use Docker to reproduce the issue:

```
docker run --rm -it -v $PWD:/s -w /s i386/golang:1.25 go test -v .
```

This library is used to hash passwords in [MediaMTX](https://github.com/bluenviron/mediamtx), that is widely popular on embedded platforms, including 32-bit Raspberry Pis. Thanks for providing the library.